### PR TITLE
Fvc format

### DIFF
--- a/bin/desi_fvc_proc.py
+++ b/bin/desi_fvc_proc.py
@@ -18,6 +18,8 @@ parser.add_argument('-i','--infile', type = str, default = None, required = True
                     help = 'path to FVC image fits file or CSV file with spots positions')
 parser.add_argument('-o','--outfile', type = str, default = None, required = True,
                     help = 'path to output CSV ASCII file')
+parser.add_argument('--extname', type = str, default = 'F0000', required = False,
+                    help = 'input EXTNAME to use if more than one HDU')
 
 args  = parser.parse_args()
 log   = get_logger()
@@ -25,7 +27,12 @@ log   = get_logger()
 filename = args.infile
 if filename.find(".fits")>0 :
     log.info("read FITS FVC image")
-    image = fitsio.read(args.infile).astype(float)
+    with fitsio.FITS(args.infile) as fx:
+        if len(fx) == 1:
+            image = fx[0].read().astype(float)
+        else:
+            image = fx[args.extname].read().astype(float)
+
     spots = detectspots(image)
 elif filename.find(".csv")>0 :
     log.info("read CSV spots table")

--- a/py/desicoord/findfiducials.py
+++ b/py/desicoord/findfiducials.py
@@ -53,7 +53,7 @@ def findfiducials(spots,separation=7.) :
     tree = KDTree(xy)
     measured_spots_distances,measured_spots_indices = tree.query(xy,k=4,distance_upper_bound=separation)
     number_of_neighbors = np.sum( measured_spots_distances<separation,axis=1)
-    fiducials_candidates_indices = np.where(number_of_neighbors>=3)[0]  # including self, so at least 3 pinholes
+    fiducials_candidates_indices = np.where(number_of_neighbors>3)[0]  # including self, so at least 3 pinholes
     
     # match candidates to known fiducials
     # nearest neighbor

--- a/py/desicoord/findfiducials.py
+++ b/py/desicoord/findfiducials.py
@@ -53,7 +53,7 @@ def findfiducials(spots,separation=7.) :
     tree = KDTree(xy)
     measured_spots_distances,measured_spots_indices = tree.query(xy,k=4,distance_upper_bound=separation)
     number_of_neighbors = np.sum( measured_spots_distances<separation,axis=1)
-    fiducials_candidates_indices = np.where(number_of_neighbors>3)[0]  # including self, so at least 3 pinholes
+    fiducials_candidates_indices = np.where(number_of_neighbors>=3)[0]  # including self, so at least 3 pinholes
     
     # match candidates to known fiducials
     # nearest neighbor
@@ -106,7 +106,7 @@ def findfiducials(spots,separation=7.) :
     
     
     for index1,index2 in zip ( fiducials_candidates_indices , matching_known_fiducials_indices ) :
-        pinholes_index1 = measured_spots_indices[index1]
+        pinholes_index1 = measured_spots_indices[index1][measured_spots_distances[index1]<separation]
         pinholes_index2 = np.where(pinholes_table["FID_ID"]==fiducials_table["FID_ID"][index2])[0]
 
         dx=spots["XPIX"][index1]-fiducials_table["XPIX"][index2]


### PR DESCRIPTION
Two updates:

* support reading multi-extension fvc-EXPID.fits.fz files written by ICS in the standard YEARMMDD/EXPID/ output directories, including selecting the desired EXTNAME if there is more than one HDU.
* fixes bug when only 3/4 fiducial pinholes are detected, fixing crash on 20191206/00030945/fvc-00030945.fits.fz HDU F0002.